### PR TITLE
actually send the stats at the specified interval

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -103,7 +103,7 @@ export class StatsStore {
     this.isDevMode = isDevMode;
     this.getAccessToken = getAccessToken;
 
-    this.timer = this.setTimer(ReportingLoopIntervalInMs);
+    this.timer = this.getTimer(ReportingLoopIntervalInMs);
 
     if (optOutValue) {
       this.optOut = !!parseInt(optOutValue, 10);
@@ -252,7 +252,7 @@ export class StatsStore {
   }
 
   /** Set a timer so we can report the stats when the time comes. */
-  private setTimer(loopInterval: number): NodeJS.Timer {
+  private getTimer(loopInterval: number): NodeJS.Timer {
     // todo (tt, 5/2018): maybe we shouldn't even set up the timer
     // in dev mode or if the user has opted out.
     const timer = setInterval(() => {

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -33,21 +33,25 @@ describe("StatsStore", function() {
     localStorage.clear();
   });
   describe("constructor", function() {
-    it("reports stats when hasReportingIntervalElapsed returns true", function(done) {
-      shouldReportStub = sinon.stub(store, "hasReportingIntervalElapsed").callsFake(() => true);
+    let clock: sinon.SinonFakeTimers;
+    beforeEach(function() {
+      clock = sinon.useFakeTimers();
       postStub.resolves({ status: 200 });
+    });
+    afterEach(function() {
+      clock.restore();
+    });
+    it("reports stats when hasReportingIntervalElapsed returns true", function() {
+      shouldReportStub = sinon.stub(store, "hasReportingIntervalElapsed").callsFake(() => true);
       setTimeout(() => {
         sinon.assert.called(postStub);
-        done();
-      // todo (tt, 5/2018): would probably be better to use sinon fake clock here.
       }, ReportingLoopIntervalInMs + 100);
     });
-    it("does not report stats when shouldReportDailyStats returns false", function(done) {
+    it("does not report stats when shouldReportDailyStats returns false", function() {
       shouldReportStub = sinon.stub(store, "hasReportingIntervalElapsed").callsFake(() => false);
       postStub.resolves({ status: 200 });
       setTimeout(() => {
         sinon.assert.notCalled(postStub);
-        done();
       }, ReportingLoopIntervalInMs + 100);
     });
   });


### PR DESCRIPTION
- Use a `setInterval` loop to periodically check if we need to send stats.  This loop is automatically set up when the store is instantiated, because I thought it would be nicer for clients of this package to not have to deal with setting up timers and such.
- add unit tests for the timer, and for the `shouldReportDailyStats` method