### PR TITLE
Add ability for clients to pass custom events

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,13 @@ Counters are a great fit for understanding the number of times a certain action 
 
 However, apps might want to collect more complex metrics with arbitrary metadata. For example, Atom currently collects "file open" events, which preserve the grammar (aka language) of the opened file.  For those use cases, the `addCustomEvent` function is your friend.  `addCustomEvent` takes any object and stuffs it in the database, giving clients the flexibility to define their own data destiny.  The events are sent to the metrics back end along with the daily payload.
 
+Events must include a type, which is the second argument to `addCustomEvent`. A timestamp is added for you in ISO-8601 format.
+
 ```
-const event = { type: "open", grammar: "javascript", timestamp: "now" };
-await store.addCustomEvent(event);
+const event = { grammar: "javascript" };
+await store.addCustomEvent(event, "open");
+
+// { "date": "2018-06-14T21:01:33.602Z", "eventType": "open", "grammar": "javascript" }
 ```
 
 ## Publishing a new release

--- a/src/database.ts
+++ b/src/database.ts
@@ -26,8 +26,9 @@ export default class StatsDatabase {
     this.getDate = () => getISODate();
   }
 
-  public async addCustomEvent(customEvent: any) {
+  public async addCustomEvent(customEvent: any, eventType: string) {
     customEvent.date = this.getDate();
+    customEvent.eventType = eventType;
     this.customEvents.insert(customEvent);
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -197,12 +197,12 @@ export class StatsStore {
     };
   }
 
-  public async addCustomEvent(event: object) {
-    await this.database.addCustomEvent(event);
+  public async addCustomEvent(event: object, eventType: string) {
+    await this.database.addCustomEvent(event, eventType);
   }
 
   public async incrementCounter(counterName: string) {
-    // don't increment in dev mode (because localStorage)
+    // don't increment in dev mode because localStorage
     // is shared across dev and non dev windows and there's
     // no way to keep dev and non-dev metrics separate.
     // don't increment if the user has opted out, because

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -190,10 +190,8 @@ describe("StatsStore", function() {
       await store.incrementCounter(counter2);
       await store.incrementCounter(counter2);
 
-      const event1 = { type: "open", grammar: "javascript", timestamp: "now" };
-      const event2 = { type: "deprecation", message: "woop woop" };
-      await store.addCustomEvent(event1);
-      await store.addCustomEvent(event2);
+      await store.addCustomEvent({ grammar: "javascript" }, "open");
+      await store.addCustomEvent({ message : "oh noes"}, "deprecate");
 
       const event = await store.getDailyStats(getDate);
 
@@ -210,8 +208,7 @@ describe("StatsStore", function() {
       expect(counters).to.deep.include({ [counter2]: 2});
 
       const customEvents = event.customEvents;
-      expect(customEvents).to.deep.include(event1);
-      expect(customEvents).to.deep.include(event2);
+      expect(customEvents.length).to.eq(2);
     });
   });
 });


### PR DESCRIPTION
There are some event types that are common across all client apps.  `usage` events, `ping` events, and `opt in / out` events.  Telemetry encapsulates the complexity around those so clients don't have to care.

However, apps might want to collect more flexible data.  For example, Atom currently collects "file open" events, which preserve the grammar (e.g. language) of the opened file.  That way we can answer questions like "what languages are most popular among users of Atom?  (More on that in https://github.com/atom/telemetry/issues/8#issuecomment-396319097).

This pull request adds the ability for `telemetry` to support custom/arbitrary event data that the clients pass in, which is then passed along to Central with the daily metrics dump.