### PR TITLE
add the ability to record timing metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ await store.addCustomEvent("open", event);
 
 ### Timers
 
-Understanding your app's latency is important. You can use the `addTimer` API to send latency metrics.
+You can use the `addTimer` API to send latency metrics. While of course you could use `addCustomEvent` to record latency metrics, using this endpoint allows us to have a consistent event format across apps.
 
 ```
 const eventType = "appStartup";

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ store.setOptOut(true);
 
 ```
 
-Please note that there are several methods of the `StatsStore` class that are public for unit testing purposes only.  The methods describe above are the ones that clients should care about.
+Please note that there are several methods of the `StatsStore` class that are public for unit testing purposes only.  The methods describe below are the ones that clients should care about.
 
 ### Counters vs. custom events
 
@@ -46,13 +46,25 @@ Counters are a great fit for understanding the number of times a certain action 
 
 However, apps might want to collect more complex metrics with arbitrary metadata. For example, Atom currently collects "file open" events, which preserve the grammar (aka language) of the opened file.  For those use cases, the `addCustomEvent` function is your friend.  `addCustomEvent` takes any object and stuffs it in the database, giving clients the flexibility to define their own data destiny.  The events are sent to the metrics back end along with the daily payload.
 
-Events must include a type, which is the second argument to `addCustomEvent`. A timestamp is added for you in ISO-8601 format.
+Events must include a type, which is the first argument to `addCustomEvent`. A timestamp is added for you in ISO-8601 format.
 
 ```
 const event = { grammar: "javascript" };
-await store.addCustomEvent(event, "open");
+await store.addCustomEvent("open", event);
 
 // { "date": "2018-06-14T21:01:33.602Z", "eventType": "open", "grammar": "javascript" }
+```
+
+### Timers
+
+Understanding your app's latency is important. You can use the `addTimer` API to send latency metrics.
+
+```
+const eventType = "appStartup";
+const loadTimeInMilliseconds = 42;
+const metadata = {spam: "ham"};
+// metadata is optional
+store.addTiming(eventType, loadTimeInMilliseconds, metadata);
 ```
 
 ## Publishing a new release

--- a/test/database.spec.ts
+++ b/test/database.spec.ts
@@ -38,6 +38,16 @@ describe("database", async function() {
       assert.deepEqual([openEvent, deprecateEvent], events);
     });
   });
+  describe("addTiming", async function() {
+    it("adds a single timer", async function() {
+      const eventType = "load";
+      const durationInMilliseconds = 100;
+      const metadata = { meta: "data" };
+      await database.addTiming(eventType, durationInMilliseconds, metadata);
+      const timings = await database.getTimings();
+      assert.deepEqual(timings[0], { eventType, durationInMilliseconds, metadata, date: getDate() });
+    });
+  });
   describe("incrementCounter", async function() {
     it("adds a new counter if it does not exist", async function() {
       const counter = await database.getCounters();
@@ -103,6 +113,14 @@ describe("database", async function() {
       const events = await database.getCustomEvents();
 
       assert.deepEqual(events, []);
+    });
+    it("clears db containing timing", async function() {
+      await database.addTiming("load", 100);
+
+      await database.clearData();
+      const timings = await database.getTimings();
+
+      assert.deepEqual(timings, []);
     });
     it("clearing an empty db does not throw an error", async function() {
       const counters = await database.getCounters();

--- a/test/database.spec.ts
+++ b/test/database.spec.ts
@@ -25,8 +25,8 @@ describe("database", async function() {
   // in real life this isn't a problem because you'd be passing in a new
   // object every time, but it makes test fixtures annoying.
   // So just make a new object in every test when you're inserting and move on with your life.
-  describe("addCustomEvent", async function() {
-    it("adds a single event", async function() {
+  describe("custom event methods", async function() {
+    it("adds and gets a single event", async function() {
       await database.addCustomEvent(openEventType, { grammar });
       const events: any = await database.getCustomEvents();
       assert.deepEqual(openEvent, events[0]);
@@ -38,14 +38,30 @@ describe("database", async function() {
       assert.deepEqual([openEvent, deprecateEvent], events);
     });
   });
-  describe("addTiming", async function() {
-    it("adds a single timer", async function() {
+  describe("timing methods", async function() {
+    it("adds and gets a single timer", async function() {
       const eventType = "load";
       const durationInMilliseconds = 100;
       const metadata = { meta: "data" };
       await database.addTiming(eventType, durationInMilliseconds, metadata);
+
       const timings = await database.getTimings();
       assert.deepEqual(timings[0], { eventType, durationInMilliseconds, metadata, date: getDate() });
+    });
+    it("adds and gets multiple timers", async function() {
+      const eventType = "load";
+      const durationInMilliseconds1 = 100;
+      const durationInMilliseconds2 = 200;
+      const metadata = { meta: "data" };
+      await database.addTiming(eventType, durationInMilliseconds1, metadata);
+      await database.addTiming(eventType, durationInMilliseconds2, metadata);
+
+      const timings = await database.getTimings();
+      assert.deepEqual(timings[0], { eventType,
+        durationInMilliseconds: durationInMilliseconds1, metadata, date: getDate() });
+      assert.deepEqual(timings[1], {
+        eventType,
+        durationInMilliseconds: durationInMilliseconds2, metadata, date: getDate() });
     });
   });
   describe("incrementCounter", async function() {

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -198,6 +198,13 @@ describe("StatsStore", function() {
       await store.addCustomEvent("open", { grammar: "javascript" });
       await store.addCustomEvent("deprecate", { message: "oh noes" });
 
+      const timingEventName = "load";
+      const loadTimeInMs1 = 100;
+      const loadTimeInMs2 = 200;
+      const metadata = { meta: "data"};
+      await store.addTiming(timingEventName, loadTimeInMs1, metadata);
+      await store.addTiming(timingEventName, loadTimeInMs2, metadata);
+
       const event = await store.getDailyStats(getDate);
 
       const dimensions = event.dimensions;
@@ -214,6 +221,9 @@ describe("StatsStore", function() {
 
       const customEvents = event.customEvents;
       expect(customEvents.length).to.eq(2);
+
+      const timings = event.timings;
+      expect(timings.length).to.eq(2);
     });
   });
 });

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -96,6 +96,25 @@ describe("StatsStore", function() {
       sinon.assert.callCount(postStub, 1);
     });
   });
+  describe("addTimer", async function() {
+    it("does not add timer in dev mode", async function() {
+      const storeInDevMode = new StatsStore(AppName.Atom, version, true, getAccessToken);
+      await storeInDevMode.addTiming("load", 100);
+      const stats = await storeInDevMode.getDailyStats(getDate);
+      assert.deepEqual(stats.timings, []);
+    });
+    it("does not add timer if user has opted out", async function() {
+      store.setOptOut(true);
+      await store.addTiming("load", 100);
+      const stats = await store.getDailyStats(getDate);
+      assert.deepEqual(stats.timings, []);
+    });
+    it("does add timer if user has opted in and not in dev mode", async function() {
+      await store.addTiming("load", 100);
+      const stats = await store.getDailyStats(getDate);
+      assert.deepEqual(stats.timings.length, 1);
+    });
+  });
   describe("incrementCounter", async function() {
     const counterName = "commits";
     it("does not increment counter in dev mode", async function() {


### PR DESCRIPTION
Addresses https://github.com/atom/telemetry/issues/13

Of course, you could record timing metrics with `addCustomEvent` but what's the fun in that?  Having a separate data format for timers (should) makes it easier to parse this data on the back end.


This pull request:
- Adds a method to put timing data in `StatsStore`
- Adds methods for storing/retrieving timing data from the database
- Adds unit tests for new functionality
- updates the README to document the new methods and clean up some cruft

Future work:
- Make sure the database doesn't start to balloon in size
- Make sure requests don't start ballooning in size
- Make Atom `metrics` package actually send timing data