### PR TITLE
pass the gitHubUser field to the metrics pipeline

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -265,7 +265,6 @@ export class StatsStore {
    * This is public for testing purposes only.
    */
   public async fetch(url: string, options: object): Promise<Response> {
-    console.log(options);
     return fetch(url, options);
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,8 @@ interface IDimensions {
   readonly eventType: "usage";
 
   readonly language: string;
+
+  readonly gitHubUser: string | null;
 }
 
 export interface IMetrics {
@@ -96,6 +98,8 @@ export class StatsStore {
    */
   private getAccessToken: () => string;
 
+  private gitHubUser: string | null;
+
   public constructor(appName: AppName, version: string, isDevMode: boolean, getAccessToken = () => "") {
     this.version = version;
     this.appUrl = baseUsageApi + appName;
@@ -103,6 +107,7 @@ export class StatsStore {
 
     this.isDevMode = isDevMode;
     this.getAccessToken = getAccessToken;
+    this.gitHubUser = null;
 
     this.timer = this.getTimer(ReportingLoopIntervalInMs);
 
@@ -117,6 +122,10 @@ export class StatsStore {
     } else {
       this.optOut = false;
     }
+  }
+
+  public setGitHubUser(gitHubUser: string) {
+    this.gitHubUser = gitHubUser;
   }
 
   /** Set whether the user has opted out of stats reporting. */
@@ -195,6 +204,7 @@ export class StatsStore {
         eventType: "usage",
         date: getDate(),
         language: process.env.LANG || "",
+        gitHubUser: this.gitHubUser,
       },
     };
   }

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -208,6 +208,9 @@ describe("StatsStore", function() {
   });
   describe("getDailyStats", async function() {
     it("event has all the fields we expect", async function() {
+      const gitHubUser = "annthurium";
+      store.setGitHubUser(gitHubUser);
+
       const counter1 = "commits";
       const counter2 = "openGitPane";
       await store.incrementCounter(counter1);
@@ -233,6 +236,7 @@ describe("StatsStore", function() {
       expect(dimensions.eventType).to.eq("usage");
       expect(dimensions.guid).to.eq(getGUID());
       expect(dimensions.language).to.eq(process.env.LANG);
+      expect(dimensions.gitHubUser).to.eq(gitHubUser);
 
       const counters = event.counters;
       expect(counters).to.deep.include({ [counter1]: 1});
@@ -243,6 +247,10 @@ describe("StatsStore", function() {
 
       const timings = event.timings;
       expect(timings.length).to.eq(2);
+    });
+    it("handles null gitHubUser", async function() {
+      const event = await store.getDailyStats(getDate);
+      expect(event.dimensions.gitHubUser).to.be.null;
     });
   });
 });


### PR DESCRIPTION
## Description of the Change
If a user has authenticated, pass their username along with metrics requests to the back end.

## Implementation
The `StatsStore` is instantiated in the atom `metrics` package.  `metrics` doesn't know what the GitHub username is, nor should it.  The GitHub package is the only package where this info is available.  Therefore, the `StatsStore` needs to have a method exposed to set the gitHubUser.  If the GitHub username has been set, that value is then passed along when daily metrics are sent to the internal analytics pipeline.  If the gitHubUser has not been set, a null value is passed along instead.

## Test plan
- [x] did a cURL request against a locally running version of `central`, to verify that requests containing a gitHubUser with a null value, and a gitHubUser with a string value both work.
```
curl -i -X POST http://localhost:4000/api/usage/atom \
  -H "Content-Type: application/json" \
  -d '[{
      	"measures": {
          "commits": 1,
          "commands": 1
      	},
      	"dimensions": {
          "appVersion": "1.27.0",
          "guid": "0f763513-e825-49d0-af94-b8e84a5870d4",
          "date": "2018-06-17T21:54:24.500Z",
          "gitHubUser": "annthurium"
      	}
      },
      {
        "measures": {
          "commits": 42,
          "commands": 420
        },
        "dimensions": {
          "appVersion": "1.30.0-dev-15e769a",
          "guid": "0f763513-e825-49d0-af94-b8e84a5870d4",
          "date":"2018-06-18T21:00:00.000Z",
          "gitHubUser": null
        }
      }
    ]'
```
- [x] unit tests to verify that if the `gitHubUser` value is set, it is included with the daily stats.  If it is not set, a null value is included instead.

## Future work
- bump `telemetry` version in metrics package.  Expose a method for setting the gitHubUser via service interface.  Clarify documentation and user facing copy to indicate that the gitHubUser is being sent with metrics requests now, and link to instructions on how to opt out of metrics reporting if they want.
- bump `metrics` version in Atom core.
- make the GitHub package set the gitHubUser, if the user has authenticated.  Tweak user facing copy so users know their gitHubUser ID is being sent with metrics requests, and link to instructions for how to opt out of metrics reporting if they want.