### PR TITLE
Unify format of timing and custom events

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -32,10 +32,10 @@ export default class StatsDatabase {
     this.getDate = () => getISODate();
   }
 
-  public async addCustomEvent(eventType: string, customEvent: any) {
-    customEvent.date = this.getDate();
-    customEvent.eventType = eventType;
-    this.customEvents.insert(customEvent);
+  public async addCustomEvent(eventType: string, metadata: any) {
+    const eventData = { ...metadata, eventType, date: this.getDate() };
+
+    this.customEvents.insert(eventData);
   }
 
   public async incrementCounter(counterName: string) {
@@ -49,7 +49,8 @@ export default class StatsDatabase {
   }
 
   public async addTiming(eventType: string, durationInMilliseconds: number, metadata = {}) {
-    const timingData = { eventType, durationInMilliseconds, metadata, date: this.getDate() };
+    const timingData = { ...metadata, eventType, durationInMilliseconds, date: this.getDate() };
+
     this.timings.insert(timingData);
   }
 

--- a/test/database.spec.ts
+++ b/test/database.spec.ts
@@ -42,26 +42,43 @@ describe("database", async function() {
     it("adds and gets a single timer", async function() {
       const eventType = "load";
       const durationInMilliseconds = 100;
-      const metadata = { meta: "data" };
+      const metadata = { field: "value" };
+
       await database.addTiming(eventType, durationInMilliseconds, metadata);
 
       const timings = await database.getTimings();
-      assert.deepEqual(timings[0], { eventType, durationInMilliseconds, metadata, date: getDate() });
+      assert.deepEqual(
+        timings[0],
+        { ...metadata, eventType, durationInMilliseconds, date: getDate() },
+      );
     });
     it("adds and gets multiple timers", async function() {
       const eventType = "load";
       const durationInMilliseconds1 = 100;
       const durationInMilliseconds2 = 200;
-      const metadata = { meta: "data" };
+      const metadata = { field: "value" };
       await database.addTiming(eventType, durationInMilliseconds1, metadata);
       await database.addTiming(eventType, durationInMilliseconds2, metadata);
 
       const timings = await database.getTimings();
-      assert.deepEqual(timings[0], { eventType,
-        durationInMilliseconds: durationInMilliseconds1, metadata, date: getDate() });
-      assert.deepEqual(timings[1], {
-        eventType,
-        durationInMilliseconds: durationInMilliseconds2, metadata, date: getDate() });
+      assert.deepEqual(
+        timings[0],
+        {
+          ...metadata,
+          eventType,
+          durationInMilliseconds: durationInMilliseconds1,
+          date: getDate(),
+        },
+      );
+      assert.deepEqual(
+        timings[1],
+        {
+          ...metadata,
+          eventType,
+          durationInMilliseconds: durationInMilliseconds2,
+          date: getDate(),
+        },
+      );
     });
   });
   describe("incrementCounter", async function() {

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -223,7 +223,7 @@ describe("StatsStore", function() {
       const timingEventName = "load";
       const loadTimeInMs1 = 100;
       const loadTimeInMs2 = 200;
-      const metadata = { meta: "data"};
+      const metadata = { field: "value"};
       await store.addTiming(timingEventName, loadTimeInMs1, metadata);
       await store.addTiming(timingEventName, loadTimeInMs2, metadata);
 


### PR DESCRIPTION
### Description of the Change

This PR removes the `metadata` sub-object from the timing events to make it consistent with the custom events so they are easier to process on the backend.

To illustrate, this is the current format of a custom event:

```json
{
  "date": "2019-01-01T14:30:38.330Z",
  "eventType": "file",
  "cm1": 71,
  "el": "text.plain.null-grammar",
  "cm2": 95,
  "aiid": "stable",
  "cd2": "x64",
  "cd3": "x64",
  "t": "event",
  "vp": "1920x1080",
  "ea": "open",
  "ec": "file",
  "sr": "1920x1080"
}
```

And this is the current format of a timing event:

```json
{
  "date": "2019-01-01T12:47:00.218Z",
  "durationInMilliseconds": 2118,
  "eventType": "load",
  "metadata": {
    "cd2": "x64",
    "cd3": "x64",
    "cm1": 47,
    "cm2": 71,
    "vp": "1920x1035",
    "ec": "shell",
    "aiid": "stable",
    "sr": "1920x1080"
  }
},
```

This change basically makes timing events share the same structure as the custom ones:

```json
{
  "date": "2019-03-19T12:47:00.218Z",
  "durationInMilliseconds": 2118,
  "eventType": "load",
  "cd2": "x64",
  "cd3": "x64",
  "cm1": 47,
  "cm2": 71,
  "vp": "1920x1035",
  "ec": "shell",
  "aiid": "stable",
  "sr": "1920x1080"
},
```

### Alternate Designs

We could have changed the custom events format (it's nice to have a `metadata` object with a free format and keep the top object with a fixed format), but since custom events are widely used already this change would mess up with the current metrics that we're logging.

### Benefits

* Consistency
* Easier processing in our backends (we can reuse the processing for custom events).

### Possible Drawbacks

Changing the format of events is not good, since this means that we'll either have to support both formats (for old and new app versions) or we're going to not be able to process events from old apps.

Good thing is that we were not handling timing events until this same week, so if there's a good moment to do this change it is now 😄.

Also, so far we only have two types of timing events, but on next Atom version we're planning to have a few more, so the earlier that we do this change the better.

### Applicable Issues

N/A

/cc @telliott27 
