### PR TITLE
Easier debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ but for right now it looks something like this:
 import StatsStore from "telemetry-github";
 
 // make a store
-const store = new StatsStore("atom", "1.24.1", false, getAccessToken);
+const store = new StatsStore("atom", "1.24.1", false, getAccessToken, options);
 
 // record a usage event
 store.incrementCounter("commit");
@@ -66,6 +66,23 @@ const metadata = {spam: "ham"};
 // metadata is optional
 store.addTiming(eventType, loadTimeInMilliseconds, metadata);
 ```
+
+### Options
+
+You can pass additional options to `telemetry` via its constructor:
+
+```js
+// The following are the default values
+const options = {
+  reportingFrequency: 86400, // How often do we want to send metrics.
+  logInDevMode: false, // Whether it should send metrics when isDevMode is true.
+  verboseMode: false, // Whether it should log the requests in the console.
+};
+
+const store = new StatsStore("atom", "1.24.1", false, getAccessToken, options);
+```
+
+All the option parameters are optional.
 
 ## Publishing a new release
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "telemetry for GitHub client apps",
   "main": "./out/index.js",
   "scripts": {
-    "mocha": "./node_modules/.bin/mocha --require mock-local-storage --compilers ts:ts-node/register ./test/*.spec.ts",
+    "mocha": "./node_modules/.bin/mocha --require mock-local-storage --require ts-node/register ./test/*.spec.ts",
     "test": "npm run mocha && npm run lint",
     "lint": "tslint -c tslint.json ./src/*.ts ./test/*.ts",
     "prepare": "tsc"


### PR DESCRIPTION
### Description of the Change

This PR adds another parameter to the constructor of the `telemetry` package to allow to pass it additional config params.

I've decided to go through this path to not cause a breaking change, but it may make sense to change the API (I don't have strong feeling about it).

The added parameters will make it easier to debug telemetry events without having to modify the code:

* **reportingFrequency**: Allows to change how often to send metrics, this is useful to not have to wait 24h to send the metrics.
* **verboseMode**: Logs all the requests that log any type of data, useful to debug if the client code works correctly.
* **logInDevMode**: This makes telemetry send events also in Dev Mode. When using this option in dev mode, `verboseMode` is automatically enabled, so users don't forget to turn this option off after debugging.

### Testing plan

Tested as part of https://github.com/atom/metrics/pull/110

### Alternate Designs

The API could be different (e.g add the other constructor arguments to the `options` object).

### Benefits

Much easier debugging of metrics. The current way to verify that a new metric is sent correctly is quite manual:

>  Check that atom/telemetry sends the correct payload to GitHub's backend. To do so, I've had to edit the code of the atom/telemetry package (more specifically, I've manually modified node_modules/telemetry-github/out/index.js to set the variable this.isDevMode to false (code). I've also had to increase how often Atom sends metrics, since by default it only sends them every 24 hours. To do so, I've set the variables DailyStatsReportIntervalInMs and ReportingLoopIntervalInMs located in the previous file to something like 15000 (code).

### Possible Drawbacks

N/A

### Applicable Issues

N/A