### PR TITLE
Fix race condition when sending daily stats

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,8 @@
     "@types/node": {
       "version": "11.13.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-11.13.0.tgz",
-      "integrity": "sha512-rx29MMkRdVmzunmiA4lzBYJNnXsW/PhG4kMBy2ATsYaDjGGR75dCFEVVROKpNwlVdcUX3xxlghKQOeDPBJobng=="
+      "integrity": "sha512-rx29MMkRdVmzunmiA4lzBYJNnXsW/PhG4kMBy2ATsYaDjGGR75dCFEVVROKpNwlVdcUX3xxlghKQOeDPBJobng==",
+      "dev": true
     },
     "@types/sinon": {
       "version": "4.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,10 +41,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.0.3.tgz",
-      "integrity": "sha512-J7nx6JzxmtT4zyvfLipYL7jNaxvlCWpyG7JhhCQ4fQyG+AGfovAHoYR55TFx+X8akfkUJYpt5JG6GPeFMjZaCQ==",
-      "dev": true
+      "version": "11.13.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.13.0.tgz",
+      "integrity": "sha512-rx29MMkRdVmzunmiA4lzBYJNnXsW/PhG4kMBy2ATsYaDjGGR75dCFEVVROKpNwlVdcUX3xxlghKQOeDPBJobng=="
     },
     "@types/sinon": {
       "version": "4.3.1",
@@ -58,7 +57,7 @@
       "integrity": "sha512-5fRLCYhLtDb3hMWqQyH10qtF+Ud2JnNCXTCZ+9ktNdCcgslcuXkDTkFcJNk++MT29yDntDnlF1+jD+uVGumsbw==",
       "dev": true,
       "requires": {
-        "@types/node": "10.0.3"
+        "@types/node": "11.13.0"
       }
     },
     "ansi-regex": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@types/node": "^11.13.0",
     "lokijs": "^1.5.4",
     "uuid": "^3.2.1"
   },
@@ -24,6 +23,7 @@
     "@types/chai-as-promised": "^7.1.0",
     "@types/lokijs": "^1.5.2",
     "@types/mocha": "^5.2.0",
+    "@types/node": "^11.13.0",
     "@types/sinon": "^4.3.1",
     "@types/uuid": "^3.4.3",
     "chai": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@types/node": "^11.13.0",
     "lokijs": "^1.5.4",
     "uuid": "^3.2.1"
   },

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -87,6 +87,12 @@ describe("StatsStore", function() {
       await storeInDevMode.reportStats(getDate);
       sinon.assert.notCalled(postStub);
     });
+    it("does not report stats when isReporting is false", async function() {
+      store.setIsReporting(true);
+      postStub.resolves({ status: 200 });
+      await store.reportStats(getDate);
+      sinon.assert.notCalled(postStub);
+    });
     it("sends a single ping event instead of reporting stats if a user has opted out", async function() {
       postStub.resolves({ status: 200 });
       store.setOptOut(true);


### PR DESCRIPTION
### Problem

@rafeca (and @shana) pointed out that there is a race condition with reporting stats.  If we have multiple client windows open, we could end up sending the same stats twice.  The db is shared across all client instances, and the database is cleared asynchronously after waiting for the request to finish.

### Solution
The fix is to add an `isReporting` class attribute, which we set to `true` at the beginning of the `reportStats` method and re-set to `false` at the end.  Since the `StatsStore` class is a singleton, and nodejs event loop is single threaded*, hopefully this will prevent multiple running windows from trying to send data at the same time.

### Alternate approaches
I also considered making each window have its own db instance.  Shana also pointed out that there might be race conditions on writes in https://github.com/atom/telemetry/issues/21.  However, I did a little research and it looks like lokijs throttles automatic saves when these would cause overlaps with a save currently in progress. This prevents data loss at the cost of less frequent saves.  So I think we're ok here, but I'm open to changing this if you disagree.