### PR TITLE
Prepare telemetry to support multiple database implementations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,26 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+      "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.0.0"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+      "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^4.0.0"
+      }
+    },
     "@sinonjs/formatio": {
       "version": "2.0.0",
       "resolved": "http://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
@@ -25,7 +45,7 @@
       "integrity": "sha512-MFiW54UOSt+f2bRw8J7LgQeIvE/9b4oGvwU7XW30S9QGAiHGnU/fmiOprsyMkdmH2rl8xSPc0/yrQw8juXU6bQ==",
       "dev": true,
       "requires": {
-        "@types/chai": "4.1.3"
+        "@types/chai": "*"
       }
     },
     "@types/lokijs": {
@@ -58,14 +78,8 @@
       "integrity": "sha512-5fRLCYhLtDb3hMWqQyH10qtF+Ud2JnNCXTCZ+9ktNdCcgslcuXkDTkFcJNk++MT29yDntDnlF1+jD+uVGumsbw==",
       "dev": true,
       "requires": {
-        "@types/node": "10.0.3"
+        "@types/node": "*"
       }
-    },
-    "ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "dev": true
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -73,7 +87,7 @@
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dev": true,
       "requires": {
-        "color-convert": "1.9.1"
+        "color-convert": "^1.9.0"
       }
     },
     "argparse": {
@@ -82,7 +96,7 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "arrify": {
@@ -97,44 +111,6 @@
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
     },
-    "babel-code-frame": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-      "dev": true,
-      "requires": {
-        "chalk": "1.1.3",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        }
-      }
-    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -147,7 +123,7 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -175,12 +151,12 @@
       "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
       "dev": true,
       "requires": {
-        "assertion-error": "1.1.0",
-        "check-error": "1.0.2",
-        "deep-eql": "3.0.1",
-        "get-func-name": "2.0.0",
-        "pathval": "1.1.0",
-        "type-detect": "4.0.8"
+        "assertion-error": "^1.0.1",
+        "check-error": "^1.0.1",
+        "deep-eql": "^3.0.0",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.0.0",
+        "type-detect": "^4.0.0"
       }
     },
     "chai-as-promised": {
@@ -189,7 +165,7 @@
       "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
       "dev": true,
       "requires": {
-        "check-error": "1.0.2"
+        "check-error": "^1.0.2"
       }
     },
     "chalk": {
@@ -198,9 +174,9 @@
       "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
       "dev": true,
       "requires": {
-        "ansi-styles": "3.2.1",
-        "escape-string-regexp": "1.0.5",
-        "supports-color": "5.4.0"
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
       },
       "dependencies": {
         "has-flag": {
@@ -215,7 +191,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -232,7 +208,7 @@
       "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
       "dev": true,
       "requires": {
-        "color-name": "1.1.3"
+        "color-name": "^1.1.1"
       }
     },
     "color-name": {
@@ -274,7 +250,7 @@
       "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
       "dev": true,
       "requires": {
-        "type-detect": "4.0.8"
+        "type-detect": "^4.0.0"
       }
     },
     "diff": {
@@ -296,9 +272,9 @@
       "dev": true
     },
     "esprima": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
     },
     "esutils": {
@@ -325,12 +301,12 @@
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "global": {
@@ -339,8 +315,8 @@
       "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
       "dev": true,
       "requires": {
-        "min-document": "2.19.0",
-        "process": "0.5.2"
+        "min-document": "^2.19.0",
+        "process": "~0.5.1"
       }
     },
     "growl": {
@@ -348,15 +324,6 @@
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
       "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
       "dev": true
-    },
-    "has-ansi": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "2.1.1"
-      }
     },
     "has-flag": {
       "version": "2.0.0",
@@ -376,8 +343,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -393,19 +360,19 @@
       "dev": true
     },
     "js-tokens": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true
     },
     "js-yaml": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
-      "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
-        "argparse": "1.0.10",
-        "esprima": "4.0.0"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       }
     },
     "just-extend": {
@@ -443,7 +410,7 @@
       "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
       "dev": true,
       "requires": {
-        "dom-walk": "0.1.1"
+        "dom-walk": "^0.1.0"
       }
     },
     "minimatch": {
@@ -452,7 +419,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -495,8 +462,8 @@
       "integrity": "sha1-iZ/zAAJ87+1HgW5txTm7BZ/M5Ik=",
       "dev": true,
       "requires": {
-        "core-js": "0.8.4",
-        "global": "4.3.2"
+        "core-js": "^0.8.3",
+        "global": "^4.3.2"
       }
     },
     "ms": {
@@ -511,11 +478,11 @@
       "integrity": "sha512-v1J/FLUB9PfGqZLGDBhQqODkbLotP0WtLo9R4EJY2PPu5f5Xg4o0rA8FDlmrjFSv9vBBKcfnOSpfYYuu5RTHqg==",
       "dev": true,
       "requires": {
-        "@sinonjs/formatio": "2.0.0",
-        "just-extend": "1.1.27",
-        "lolex": "2.3.2",
-        "path-to-regexp": "1.7.0",
-        "text-encoding": "0.6.4"
+        "@sinonjs/formatio": "^2.0.0",
+        "just-extend": "^1.1.27",
+        "lolex": "^2.3.2",
+        "path-to-regexp": "^1.7.0",
+        "text-encoding": "^0.6.4"
       }
     },
     "once": {
@@ -524,7 +491,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "path-is-absolute": {
@@ -534,9 +501,9 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
     "path-to-regexp": {
@@ -561,12 +528,12 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
-      "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.0.tgz",
+      "integrity": "sha512-WL2pBDjqT6pGUNSUzMw00o4T7If+z4H2x3Gz893WoUQ5KW8Vr9txp00ykiP16VBaZF5+j/OcXJHZ9+PCvdiDKw==",
       "dev": true,
       "requires": {
-        "path-parse": "1.0.5"
+        "path-parse": "^1.0.6"
       }
     },
     "samsam": {
@@ -576,9 +543,9 @@
       "dev": true
     },
     "semver": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
       "dev": true
     },
     "sinon": {
@@ -587,13 +554,13 @@
       "integrity": "sha512-kzBkET1Hf0r0J4uVnlicuAEiq9nnhPrEHZWS0mds+5EaB9rA0XoliIkLaqkBNU9lwPuJACo/velUQQOmTRJtUw==",
       "dev": true,
       "requires": {
-        "@sinonjs/formatio": "2.0.0",
-        "diff": "3.5.0",
-        "lodash.get": "4.4.2",
-        "lolex": "2.3.2",
-        "nise": "1.3.3",
-        "supports-color": "5.4.0",
-        "type-detect": "4.0.8"
+        "@sinonjs/formatio": "^2.0.0",
+        "diff": "^3.1.0",
+        "lodash.get": "^4.4.2",
+        "lolex": "^2.2.0",
+        "nise": "^1.2.0",
+        "supports-color": "^5.1.0",
+        "type-detect": "^4.0.5"
       },
       "dependencies": {
         "has-flag": {
@@ -608,7 +575,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -625,8 +592,8 @@
       "integrity": "sha512-mR7/Nd5l1z6g99010shcXJiNEaf3fEtmLhRB/sBcQVJGodcHCULPp2y4Sfa43Kv2zq7T+Izmfp/WHCR6dYkQCA==",
       "dev": true,
       "requires": {
-        "buffer-from": "1.0.0",
-        "source-map": "0.6.1"
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "sprintf-js": {
@@ -635,22 +602,13 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
-    "strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "2.1.1"
-      }
-    },
     "supports-color": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
       "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
       "dev": true,
       "requires": {
-        "has-flag": "2.0.0"
+        "has-flag": "^2.0.0"
       }
     },
     "text-encoding": {
@@ -665,14 +623,14 @@
       "integrity": "sha512-H/KWK27B3JJAc5WFOBBUxN638DukbV8PptdQgiHWPO2SGDVJzuVOl8Ye0XJ5+FiZIdFtgUuGOJRV4c/XBQ5dBg==",
       "dev": true,
       "requires": {
-        "arrify": "1.0.1",
-        "chalk": "2.4.1",
-        "diff": "3.5.0",
-        "make-error": "1.3.4",
-        "minimist": "1.2.0",
-        "mkdirp": "0.5.1",
-        "source-map-support": "0.5.5",
-        "yn": "2.0.0"
+        "arrify": "^1.0.0",
+        "chalk": "^2.3.0",
+        "diff": "^3.1.0",
+        "make-error": "^1.1.1",
+        "minimist": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "source-map-support": "^0.5.3",
+        "yn": "^2.0.0"
       },
       "dependencies": {
         "minimist": {
@@ -684,46 +642,47 @@
       }
     },
     "tslib": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.1.tgz",
-      "integrity": "sha512-avfPS28HmGLLc2o4elcc2EIq2FcH++Yo5YxpBZi9Yw93BCTGFthI4HPE4Rpep6vSYQaK8e69PelM44tPj+RaQg==",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
       "dev": true
     },
     "tslint": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.10.0.tgz",
-      "integrity": "sha1-EeJrzLiK+gLdDZlWyuPUVAtfVMM=",
+      "version": "5.16.0",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.16.0.tgz",
+      "integrity": "sha512-UxG2yNxJ5pgGwmMzPMYh/CCnCnh0HfPgtlVRDs1ykZklufFBL1ZoTlWFRz2NQjcoEiDoRp+JyT0lhBbbH/obyA==",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "builtin-modules": "1.1.1",
-        "chalk": "2.4.1",
-        "commander": "2.15.1",
-        "diff": "3.5.0",
-        "glob": "7.1.2",
-        "js-yaml": "3.11.0",
-        "minimatch": "3.0.4",
-        "resolve": "1.7.1",
-        "semver": "5.5.0",
-        "tslib": "1.9.1",
-        "tsutils": "2.27.0"
+        "@babel/code-frame": "^7.0.0",
+        "builtin-modules": "^1.1.1",
+        "chalk": "^2.3.0",
+        "commander": "^2.12.1",
+        "diff": "^3.2.0",
+        "glob": "^7.1.1",
+        "js-yaml": "^3.13.0",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.1",
+        "resolve": "^1.3.2",
+        "semver": "^5.3.0",
+        "tslib": "^1.8.0",
+        "tsutils": "^2.29.0"
       },
       "dependencies": {
         "commander": {
-          "version": "2.15.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+          "version": "2.20.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+          "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
           "dev": true
         }
       }
     },
     "tsutils": {
-      "version": "2.27.0",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.27.0.tgz",
-      "integrity": "sha512-JcyX25oM9pFcb3zh60OqG1St8p/uSqC5Bgipdo3ieacB/Ao4dPhm7hAtKT9NrEu23CyYrrgJPV3CqYfo+/+T4w==",
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
+      "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
       "dev": true,
       "requires": {
-        "tslib": "1.9.1"
+        "tslib": "^1.8.1"
       }
     },
     "type-detect": {
@@ -733,9 +692,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.8.3.tgz",
-      "integrity": "sha512-K7g15Bb6Ra4lKf7Iq2l/I5/En+hLIHmxWZGq3D4DIRNFxMNV6j2SHSvDOqs2tGd4UvD/fJvrwopzQXjLrT7Itw==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
+      "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==",
       "dev": true
     },
     "uuid": {

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "telemetry for GitHub client apps",
   "main": "./out/index.js",
   "scripts": {
-    "mocha": "./node_modules/.bin/mocha --require mock-local-storage --require ts-node/register ./test/*.spec.ts",
+    "mocha": "./node_modules/.bin/mocha --require mock-local-storage --require ts-node/register ./test/**.spec.ts",
     "test": "npm run mocha && npm run lint",
-    "lint": "tslint -c tslint.json ./src/*.ts ./test/*.ts",
+    "lint": "tsc && tslint -c tslint.json ./src/**.ts ./test/**.ts",
     "prepare": "tsc"
   },
   "author": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "mock-local-storage": "^1.0.5",
     "sinon": "^5.0.3",
     "ts-node": "^6.0.2",
-    "tslint": "^5.10.0",
-    "typescript": "^2.8.3"
+    "tslint": "^5.16.0",
+    "typescript": "^3.4.5"
   }
 }

--- a/src/databases/base.ts
+++ b/src/databases/base.ts
@@ -1,0 +1,19 @@
+export interface IBaseDatabase {
+  addCustomEvent(eventType: string, customEvent: any): Promise<unknown>;
+
+  incrementCounter(counterName: string): Promise<unknown>;
+
+  addTiming(
+    eventType: string,
+    durationInMilliseconds: number,
+    metadata: object | undefined,
+  ): Promise<unknown>;
+
+  clearData(): Promise<unknown>;
+
+  getTimings(): Promise<object[]>;
+
+  getCustomEvents(): Promise<object[]>;
+
+  getCounters(): Promise<{[name: string]: number}>;
+}

--- a/src/databases/base.ts
+++ b/src/databases/base.ts
@@ -1,5 +1,5 @@
 export interface IBaseDatabase {
-  addCustomEvent(eventType: string, customEvent: any): Promise<unknown>;
+  addCustomEvent(eventType: string, customEvent: object): Promise<unknown>;
 
   incrementCounter(counterName: string): Promise<unknown>;
 
@@ -11,9 +11,25 @@ export interface IBaseDatabase {
 
   clearData(): Promise<unknown>;
 
-  getTimings(): Promise<object[]>;
+  getTimings(): Promise<ITimingEvent[]>;
 
-  getCustomEvents(): Promise<object[]>;
+  getCustomEvents(): Promise<ICustomEvent[]>;
 
-  getCounters(): Promise<{[name: string]: number}>;
+  getCounters(): Promise<ICounters>;
+}
+
+export interface ICounters {
+  [name: string]: number;
+}
+
+export interface ITimingEvent {
+  date: string;
+  eventType: string;
+  durationInMilliseconds: number;
+  metadata: object;
+}
+
+export interface ICustomEvent {
+  date: string;
+  eventType: string;
 }

--- a/src/databases/base.ts
+++ b/src/databases/base.ts
@@ -1,4 +1,4 @@
-export interface IBaseDatabase {
+export interface BaseDatabase {
   addCustomEvent(eventType: string, customEvent: object): Promise<unknown>;
 
   incrementCounter(counterName: string): Promise<unknown>;
@@ -11,25 +11,25 @@ export interface IBaseDatabase {
 
   clearData(): Promise<unknown>;
 
-  getTimings(): Promise<ITimingEvent[]>;
+  getTimings(): Promise<TimingEvent[]>;
 
-  getCustomEvents(): Promise<ICustomEvent[]>;
+  getCustomEvents(): Promise<CustomEvent[]>;
 
-  getCounters(): Promise<ICounters>;
+  getCounters(): Promise<Counters>;
 }
 
-export interface ICounters {
+export interface Counters {
   [name: string]: number;
 }
 
-export interface ITimingEvent {
+export interface TimingEvent {
   date: string;
   eventType: string;
   durationInMilliseconds: number;
   metadata: object;
 }
 
-export interface ICustomEvent {
+export interface CustomEvent {
   date: string;
   eventType: string;
 }

--- a/src/databases/loki.ts
+++ b/src/databases/loki.ts
@@ -1,8 +1,8 @@
 import * as loki from "lokijs";
-import {IBaseDatabase, ICounters, ITimingEvent, ICustomEvent} from "./base";
+import {BaseDatabase, Counters, TimingEvent, CustomEvent} from "./base";
 import {getISODate} from "../util";
 
-export default class LokiDatabase implements IBaseDatabase {
+export default class LokiDatabase implements BaseDatabase {
 
   /**
    * Counters which can be incremented.
@@ -20,12 +20,12 @@ export default class LokiDatabase implements IBaseDatabase {
    * Events are an object, to give clients maximal flexibility.  Date is automatically added
    * for you in ISO-8601 format.
    */
-  private customEvents: Collection<ICustomEvent>;
+  private customEvents: Collection<CustomEvent>;
 
   /**
    * Timing is used to record application metrics that deal with latency.
    */
-  private timings: Collection<ITimingEvent>;
+  private timings: Collection<TimingEvent>;
 
   public constructor() {
     const db = new loki("stats-database");
@@ -35,7 +35,7 @@ export default class LokiDatabase implements IBaseDatabase {
   }
 
   public async addCustomEvent(eventType: string, customEvent: object) {
-    const eventToInsert: ICustomEvent = {
+    const eventToInsert: CustomEvent = {
       ...customEvent,
       date: getISODate(),
       eventType,
@@ -68,7 +68,7 @@ export default class LokiDatabase implements IBaseDatabase {
     await this.timings.clear();
   }
 
-  public async getTimings(): Promise<ITimingEvent[]> {
+  public async getTimings(): Promise<TimingEvent[]> {
     const timings = await this.timings.find();
     timings.forEach((timing) => {
       delete timing.$loki;
@@ -78,7 +78,7 @@ export default class LokiDatabase implements IBaseDatabase {
     return timings;
   }
 
-  public async getCustomEvents(): Promise<ICustomEvent[]> {
+  public async getCustomEvents(): Promise<CustomEvent[]> {
     const events = await this.customEvents.find();
     events.forEach((event) => {
       // honey badger don't care about lokijis meta data.
@@ -93,8 +93,8 @@ export default class LokiDatabase implements IBaseDatabase {
    * callers shouldn't care about.
    * Returns something like { commits: 7, coAuthoredCommits: 8 }.
    */
-  public async getCounters(): Promise<ICounters> {
-    const counters: ICounters = {};
+  public async getCounters(): Promise<Counters> {
+    const counters: Counters = {};
     this.counters.find().forEach((counter) => {
       counters[counter.name] = counter.count;
     });

--- a/src/databases/loki.ts
+++ b/src/databases/loki.ts
@@ -2,7 +2,7 @@ import * as loki from "lokijs";
 import {IBaseDatabase, ICounters, ITimingEvent, ICustomEvent} from "./base";
 import {getISODate} from "../util";
 
-export default class StatsDatabase implements IBaseDatabase {
+export default class LokiDatabase implements IBaseDatabase {
 
   /**
    * Counters which can be incremented.

--- a/src/databases/loki.ts
+++ b/src/databases/loki.ts
@@ -1,6 +1,7 @@
 import * as loki from "lokijs";
+import {IBaseDatabase} from "./base";
 
-export default class StatsDatabase {
+export default class StatsDatabase implements IBaseDatabase {
 
   /**
    * Counters which can be incremented.

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,7 +87,7 @@ export class StatsStore {
   private isDevMode: boolean;
 
   /** Instance of a class thats stores metrics so they can be stored across sessions */
-  private database = new StatsDatabase(getISODate);
+  private database = new StatsDatabase();
 
   /** function for getting GitHub access token if one exists.
    * We don't want to store the token, due to security concerns, and also

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { getGUID } from "./uuid";
-import StatsDatabase from "./database";
+import StatsDatabase from "./databases/loki";
 
 // if you're running a local instance of central, use
 // "http://localhost:4000/api/usage/" instead.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { getGUID } from "./uuid";
-import {IBaseDatabase, ITimingEvent, ICustomEvent, ICounters} from "./databases/base";
+import {BaseDatabase, TimingEvent, CustomEvent, Counters} from "./databases/base";
 import StatsDatabase from "./databases/loki";
 import {getISODate} from "./util";
 
@@ -21,7 +21,7 @@ const hours = 60 * 60 * 1000;
 /** How often daily stats should be submitted (i.e., 24 hours). */
 export const DailyStatsReportIntervalInMs = hours * 24;
 
-interface IDimensions {
+interface Dimensions {
   /** The app version. */
   readonly appVersion: string;
 
@@ -41,16 +41,16 @@ interface IDimensions {
   readonly gitHubUser: string | null;
 }
 
-export interface IMetrics {
-  dimensions: IDimensions;
+export interface Metrics {
+  dimensions: Dimensions;
   // object with the value for each counter name.
-  measures: ICounters;
+  measures: Counters;
 
   // array of custom events that can be defined by the client
-  customEvents: ICustomEvent[];
+  customEvents: CustomEvent[];
 
   // array of timing events
-  timings: ITimingEvent[];
+  timings: TimingEvent[];
 }
 
 /** The goal is for this package to be app-agnostic so we can add
@@ -83,7 +83,7 @@ export class StatsStore {
   private isDevMode: boolean;
 
   /** Instance of a class thats stores metrics so they can be stored across sessions */
-  private database: IBaseDatabase;
+  private database: BaseDatabase;
 
   /** function for getting GitHub access token if one exists.
    * We don't want to store the token, due to security concerns, and also
@@ -207,7 +207,7 @@ export class StatsStore {
   }
 
   // public for testing purposes only
-  public async getDailyStats(): Promise<IMetrics> {
+  public async getDailyStats(): Promise<Metrics> {
     return {
       measures: await this.database.getCounters(),
       customEvents: await this.database.getCustomEvents(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { getGUID } from "./uuid";
+import {IBaseDatabase, ITimingEvent, ICustomEvent, ICounters} from "./databases/base";
 import StatsDatabase from "./databases/loki";
 import {getISODate} from "./util";
 
@@ -42,15 +43,14 @@ interface IDimensions {
 
 export interface IMetrics {
   dimensions: IDimensions;
-  // metrics names are defined by the client and thus aren't knowable
-  // at compile time here.
-  measures: object;
+  // object with the value for each counter name.
+  measures: ICounters;
 
   // array of custom events that can be defined by the client
-  customEvents: object[];
+  customEvents: ICustomEvent[];
 
   // array of timing events
-  timings: object[];
+  timings: ITimingEvent[];
 }
 
 /** The goal is for this package to be app-agnostic so we can add
@@ -83,7 +83,7 @@ export class StatsStore {
   private isDevMode: boolean;
 
   /** Instance of a class thats stores metrics so they can be stored across sessions */
-  private database = new StatsDatabase();
+  private database: IBaseDatabase;
 
   /** function for getting GitHub access token if one exists.
    * We don't want to store the token, due to security concerns, and also
@@ -110,6 +110,7 @@ export class StatsStore {
       verboseMode?: boolean,
     } = {},
   ) {
+    this.database = new StatsDatabase();
     this.version = version;
     this.appUrl = baseUsageApi + appName;
     const optOutValue = localStorage.getItem(StatsOptOutKey);
@@ -270,7 +271,7 @@ export class StatsStore {
     if (token) {
       requestHeaders.Authorization = `token ${token}`;
     }
-    const options: object = {
+    const options = {
       method: "POST",
       headers: requestHeaders,
       body: JSON.stringify(body),

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,3 @@
+export function getISODate() {
+  return new Date().toISOString();
+}

--- a/test/databases/loki.spec.ts
+++ b/test/databases/loki.spec.ts
@@ -1,5 +1,5 @@
 import { assert } from "chai";
-import StatsDatabase from "../src/database";
+import StatsDatabase from "../../src/databases/loki";
 
 const getDate = () => {
   return "2018-05-16T21:54:24.500Z";

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -10,10 +10,6 @@ const ReportingLoopIntervalInMs = DailyStatsReportIntervalInMs / 6;
 
 chai.use(chaiAsPromised);
 
-const getDate = () => {
-  return "2018-05-16T21:54:24.500Z";
-};
-
 const ACCESS_TOKEN = "SUPER_AWESOME_ACCESS_TOKEN";
 
 const getAccessToken = () => {
@@ -59,39 +55,47 @@ describe("StatsStore", function() {
   });
   describe("reportStats", async function() {
     let fakeEvent: IMetrics;
+    let clock: sinon.SinonFakeTimers;
+
     beforeEach(async function() {
+      clock = sinon.useFakeTimers();
       await store.incrementCounter("commit");
-      fakeEvent = await store.getDailyStats(getDate);
+      fakeEvent = await store.getDailyStats();
     });
+
+    afterEach(function() {
+      clock.restore();
+    });
+
     it("handles success case", async function() {
       postStub.resolves({ status: 200 });
-      await store.reportStats(getDate);
+      await store.reportStats();
       sinon.assert.calledWith(postStub, fakeEvent);
 
       // counters should be cleared in success case
-      const counters = (await store.getDailyStats(getDate)).measures;
+      const counters = (await store.getDailyStats()).measures;
       assert.deepEqual(counters, {});
     });
     it("handles failure case", async function() {
       postStub.resolves({ status: 500 });
-      await store.reportStats(getDate);
+      await store.reportStats();
       sinon.assert.calledWith(postStub, fakeEvent);
 
       // counters should not be cleared if we fail to send daily stats
-      const counters = (await store.getDailyStats(getDate)).measures;
+      const counters = (await store.getDailyStats()).measures;
       assert.deepEqual(counters, fakeEvent.measures);
     });
     it("does not report stats when app is in dev mode", async function() {
       const storeInDevMode = new StatsStore(AppName.Atom, version, true, getAccessToken);
       postStub = sinon.stub(storeInDevMode, "post").resolves( { status: 200 });
-      await storeInDevMode.reportStats(getDate);
+      await storeInDevMode.reportStats();
       sinon.assert.notCalled(postStub);
     });
     it("sends a single ping event instead of reporting stats if a user has opted out", async function() {
       postStub.resolves({ status: 200 });
       store.setOptOut(true);
-      await store.reportStats(getDate);
-      await store.reportStats(getDate);
+      await store.reportStats();
+      await store.reportStats();
       sinon.assert.calledWith(postStub, pingEvent);
 
       // event should only be sent the first time even though we call report stats
@@ -102,18 +106,18 @@ describe("StatsStore", function() {
     it("does not add timer in dev mode", async function() {
       const storeInDevMode = new StatsStore(AppName.Atom, version, true, getAccessToken);
       await storeInDevMode.addTiming("load", 100);
-      const stats = await storeInDevMode.getDailyStats(getDate);
+      const stats = await storeInDevMode.getDailyStats();
       assert.deepEqual(stats.timings, []);
     });
     it("does not add timer if user has opted out", async function() {
       store.setOptOut(true);
       await store.addTiming("load", 100);
-      const stats = await store.getDailyStats(getDate);
+      const stats = await store.getDailyStats();
       assert.deepEqual(stats.timings, []);
     });
     it("does add timer if user has opted in and not in dev mode", async function() {
       await store.addTiming("load", 100);
-      const stats = await store.getDailyStats(getDate);
+      const stats = await store.getDailyStats();
       assert.deepEqual(stats.timings.length, 1);
     });
   });
@@ -122,18 +126,18 @@ describe("StatsStore", function() {
     it("does not increment counter in dev mode", async function() {
       const storeInDevMode = new StatsStore(AppName.Atom, version, true, getAccessToken);
       await storeInDevMode.incrementCounter(counterName);
-      const stats = await storeInDevMode.getDailyStats(getDate);
+      const stats = await storeInDevMode.getDailyStats();
       assert.deepEqual(stats.measures, {});
     });
     it("does not increment counter if user has opted out", async function() {
       store.setOptOut(true);
       await store.incrementCounter(counterName);
-      const stats = await store.getDailyStats(getDate);
+      const stats = await store.getDailyStats();
       assert.deepEqual(stats.measures, {});
     });
     it("does increment counter if non dev and user has opted in", async function() {
       await store.incrementCounter(counterName);
-      const stats = await store.getDailyStats(getDate);
+      const stats = await store.getDailyStats();
       assert.deepEqual(stats.measures, {[counterName]: 1});
     });
   });
@@ -141,7 +145,7 @@ describe("StatsStore", function() {
     it("sends the auth header if one exists", async function() {
       store = new StatsStore(AppName.Atom, version, false, getAccessToken);
       const fetch: sinon.SinonStub = sinon.stub(store, "fetch").resolves({ status: 200 });
-      await store.reportStats(getDate);
+      await store.reportStats();
       assert.deepEqual(fetch.args[0][1].headers, {
         "Content-Type": "application/json",
         "Authorization": `token ${ACCESS_TOKEN}`,
@@ -150,7 +154,7 @@ describe("StatsStore", function() {
     it("does not send the auth header if the auth header is falsy", async function() {
       store = new StatsStore(AppName.Atom, version, false, () => "");
       const fetch: sinon.SinonStub = sinon.stub(store, "fetch").resolves({ status: 200 });
-      await store.reportStats(getDate);
+      await store.reportStats();
       assert.deepEqual(fetch.args[0][1].headers, {
         "Content-Type": "application/json",
       });
@@ -160,7 +164,7 @@ describe("StatsStore", function() {
 
       store = new StatsStore(AppName.Atom, version, false, getAccessToken, {verboseMode: true});
       const fetch: sinon.SinonStub = sinon.stub(store, "fetch").resolves({ status: 200 });
-      await store.reportStats(getDate);
+      await store.reportStats();
       assert.deepEqual(fetch.args[0][1].headers, {
         "Content-Type": "application/json",
         "Authorization": `token ${ACCESS_TOKEN}`,
@@ -173,7 +177,7 @@ describe("StatsStore", function() {
 
       store = new StatsStore(AppName.Atom, version, true, getAccessToken, {logInDevMode: true});
       const fetch: sinon.SinonStub = sinon.stub(store, "fetch").resolves({ status: 200 });
-      await store.reportStats(getDate);
+      await store.reportStats();
       assert.deepEqual(fetch.args[0][1].headers, {
         "Content-Type": "application/json",
         "Authorization": `token ${ACCESS_TOKEN}`,
@@ -267,12 +271,11 @@ describe("StatsStore", function() {
       await store.addTiming(timingEventName, loadTimeInMs1, metadata);
       await store.addTiming(timingEventName, loadTimeInMs2, metadata);
 
-      const event = await store.getDailyStats(getDate);
+      const event = await store.getDailyStats();
 
       const dimensions = event.dimensions;
       expect(dimensions.appVersion).to.eq(version);
       expect(dimensions.platform).to.eq(process.platform);
-      expect(dimensions.date).to.eq(getDate());
       expect(dimensions.eventType).to.eq("usage");
       expect(dimensions.guid).to.eq(getGUID());
       expect(dimensions.language).to.eq(process.env.LANG);
@@ -289,7 +292,7 @@ describe("StatsStore", function() {
       expect(timings.length).to.eq(2);
     });
     it("handles null gitHubUser", async function() {
-      const event = await store.getDailyStats(getDate);
+      const event = await store.getDailyStats();
       expect(event.dimensions.gitHubUser).to.be.null;
     });
   });

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1,6 +1,6 @@
 import { expect, assert } from "chai";
 import { AppName, DailyStatsReportIntervalInMs, HasSentOptInPingKey,
-  LastDailyStatsReportKey, IMetrics, StatsOptOutKey, StatsStore } from "../src/index";
+  LastDailyStatsReportKey, Metrics, StatsOptOutKey, StatsStore } from "../src/index";
 import * as sinon from "sinon";
 import * as chai from "chai";
 import * as chaiAsPromised from "chai-as-promised";
@@ -54,7 +54,7 @@ describe("StatsStore", function() {
     });
   });
   describe("reportStats", async function() {
-    let fakeEvent: IMetrics;
+    let fakeEvent: Metrics;
     let clock: sinon.SinonFakeTimers;
 
     beforeEach(async function() {

--- a/tslint.json
+++ b/tslint.json
@@ -5,6 +5,7 @@
     ],
     "jsRules": {},
     "rules": {
+      "interface-name": false,
       "object-literal-sort-keys": false,
       "only-arrow-functions": false,
       "no-console": false,


### PR DESCRIPTION
This PR does some minimum changes to the `telemetry` package to allow supporting multiple implementation of databases.

This will allow us to tackle https://github.com/atom/telemetry/issues/26 by creating a new `IndexedDB` database implementation.

In order to do so, I've moved the `database.ts` file to `databases/loki.ts` and created a `databases/base.ts` which contains the TypeScript interface that all database implementations will have to follow.

Additional changes that I've done as part of this PR (I'd loved to make them as separate PRs but they are all dependant between each other, and dependant PRs on GitHub are not handled very well 😅):

* Upgraded TypeScript version to v3 (to support `unknown` type).
* Refined some TypeScript types that were `any` or `object` before.
* Remove the injection of the `getDate()` implementation since it was only done for testing purposes. Instead I've modified the tests.