### PR TITLE
Fix race condition when sending daily stats (take 2)

### DIFF
--- a/src/databases/indexeddb.ts
+++ b/src/databases/indexeddb.ts
@@ -12,11 +12,9 @@ export default class IndexedDBDatabase implements BaseDatabase {
       },
     },
     customEvents: {
-      key: "name",
       value: CustomEvent,
     },
     timingEvents: {
-      key: "name",
       value: TimingEvent,
     },
   }>>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -139,6 +139,10 @@ export class StatsStore {
     }
   }
 
+  public end() {
+    clearInterval(this.timer);
+  }
+
   public setGitHubUser(gitHubUser: string) {
     this.gitHubUser = gitHubUser;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -295,19 +295,10 @@ export class StatsStore {
    * Public for testing purposes only.
    */
   public hasReportingIntervalElapsed(): boolean {
-
-    const lastDateString = localStorage.getItem(LastDailyStatsReportKey);
-    let lastDate = 0;
-    if (lastDateString && lastDateString.length > 0) {
-      lastDate = parseInt(lastDateString, 10);
-    }
-
-    if (isNaN(lastDate)) {
-      lastDate = 0;
-    }
-
-    const now = Date.now();
-    return (now - lastDate) > this.reportingFrequency;
+    return this.isDateBefore(
+      localStorage.getItem(LastDailyStatsReportKey),
+      this.reportingFrequency,
+    );
   }
 
   /** Set a timer so we can report the stats when the time comes. */
@@ -326,5 +317,26 @@ export class StatsStore {
       timer.unref();
     }
     return timer;
+  }
+
+  /**
+   * Helper method that returns whether the difference between the current date and the specified date is
+   * less than the specified amount of milliseconds.
+   *
+   * The pass date should be a string representing the number of milliseconds elapsed since
+   * January 1, 1970 00:00:00 UTC.
+   */
+  private isDateBefore(dateAsString: string | null, numMilliseconds: number): boolean {
+    if (!dateAsString || dateAsString.length === 0) {
+      return true;
+    }
+
+    const date = parseInt(dateAsString, 10);
+
+    if (isNaN(date)) {
+      return true;
+    }
+
+    return (Date.now() - date) > numMilliseconds;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,9 @@ export const LastDailyStatsReportKey = "last-daily-stats-report";
 /** The localStorage key for whether the user has opted out. */
 export const StatsOptOutKey = "stats-opt-out";
 
+/** The localStorage key that indicates that we're sending the stats to the server. */
+export const SendingStatsKey = "metrics:stats-being-sent";
+
 /** Have we successfully sent the stats opt-in? */
 export const HasSentOptInPingKey = "has-sent-stats-opt-in-ping";
 
@@ -20,6 +23,9 @@ const hours = 60 * 60 * 1000;
 
 /** How often daily stats should be submitted (i.e., 24 hours). */
 export const DailyStatsReportIntervalInMs = hours * 24;
+
+/** After this amount of time we'll. */
+export const TimeoutForReportingLock = hours * 2;
 
 interface Dimensions {
   /** The app version. */
@@ -164,10 +170,26 @@ export class StatsStore {
     if (this.optOut || this.isDevMode) {
       return;
     }
-    const stats = await this.getDailyStats();
+
+    // If multiple instances of `telemetry` are being run from different
+    // renderer process, we want to avoid two instances to send the same
+    // stats.
+    // We use a timed mutex so if for some reason the lock is not released
+    // after reporting the metrics the metrics can still be sent after some
+    // timeout.
+    if (!this.isDateBefore(
+      localStorage.getItem(SendingStatsKey),
+      TimeoutForReportingLock,
+    )) {
+      return;
+    }
+
+    localStorage.setItem(SendingStatsKey, Date.now().toString());
 
     try {
+      const stats = await this.getDailyStats();
       const response = await this.post(stats);
+
       if (response.status !== 200) {
         throw new Error(`Stats reporting failure: ${response.status})`);
       } else {
@@ -179,6 +201,10 @@ export class StatsStore {
       // todo (tt, 5/2018): would be good to log these errors to Haystack/Datadog
       // so we have some kind of visibility into how often things are failing.
       console.log(err);
+    } finally {
+      // Delete the "mutex" used to ensure that stats are not sent at the same time by
+      // two different processes.
+      localStorage.removeItem(SendingStatsKey);
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -177,13 +177,15 @@ export class StatsStore {
     // We use a timed mutex so if for some reason the lock is not released
     // after reporting the metrics the metrics can still be sent after some
     // timeout.
+    // Remember to not perform async operations between the `localStorage.setItem()`
+    // and the `localStorage.getItem()` calls. This way we can take advantage of the
+    // LocalStorage mutex on Chrome: https://www.w3.org/TR/webstorage/#threads
     if (!this.isDateBefore(
       localStorage.getItem(SendingStatsKey),
       TimeoutForReportingLock,
     )) {
       return;
     }
-
     localStorage.setItem(SendingStatsKey, Date.now().toString());
 
     try {


### PR DESCRIPTION
## Summary

This PR adds a simple locking system using the `localStorage` mechanism to prevent two different instances of `telemetry` (which could run in parallel from different windows/tabs in a browser/electron environment).

This, combined with https://github.com/atom/telemetry/pull/28, should solve most concurrency issues on the `telemetry` package.

## Remaining issue

There's still one remaining potential issue which is minor (at least compared to this one and the one fixed by https://github.com/atom/telemetry/pull/28):

**Any event happening while the reporting is being done is lost**: Since happens because we're clearing all the events once the current events are being reported.

In order to fix this, we have two options:

1. Implement a queueing system which places the events that happen while previous events are being sent in a temporary structure and then stores them in the database once the events got sent successfully.
2. Instead of deleting all events from the database once they are sent, only delete the ones that were actually sent (this could potentially be slow or harder to implement).

Anyways, we should fix this remaining issue as a separate PR since it's orthogonal to this work.