### PR TITLE
Reduce the maximum delay time to send metrics to 10 minutes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,8 +18,14 @@ export const SendingStatsKey = "metrics:stats-being-sent";
 /** Have we successfully sent the stats opt-in? */
 export const HasSentOptInPingKey = "has-sent-stats-opt-in-ping";
 
+/** milliseconds in a minute (for readability, dawg) */
+const minutes = 60 * 1000;
+
 /** milliseconds in an hour (for readability, dawg) */
-const hours = 60 * 60 * 1000;
+const hours = 60 * minutes;
+
+/** How often do we want to check to report stats (also the delay until the first report). */
+const MaxReportingFrequency = 10 * minutes;
 
 /** How often daily stats should be submitted (i.e., 24 hours). */
 export const DailyStatsReportIntervalInMs = hours * 24;
@@ -130,7 +136,7 @@ export class StatsStore {
     // We set verbose mode when logging in Dev mode to prevent users from forgetting to turn
     // off the logging in dev mode.
     this.verboseMode = (!!options.logInDevMode && isDevMode) || !!options.verboseMode;
-    this.timer = this.getTimer(this.reportingFrequency / 6);
+    this.timer = this.getTimer(Math.min(this.reportingFrequency / 6, MaxReportingFrequency));
 
     if (optOutValue) {
       this.optOut = !!parseInt(optOutValue, 10);


### PR DESCRIPTION
## Problem

Currently, due to the `setInterval()` call happening on the [`getTimer()` function](https://github.com/atom/telemetry/blob/master/src/index.ts#L340), events are sent 4 hours after the `telemetry` package has been initialized (this is because the `reportingFrequency` is 24 hours by default so 6 times less it's the 4 hours).

This means that if a user only creates short-lived sessions (which last less than 4 hours), `telemetry` will never report stats for her.

## Solution

This PR changes the timeout of the `setInterval()` function to have a maximum value of 10 minutes (instead of the 4 hours) in case the calculation of 6 times less than the `reportingFrequency` is greater than that value.

On other cases, the previous calculation logic is kept (this is to allow customizing the `reportingFrequency` to values like 1 minutes for debugging purposes).

I've chosen the 10 minutes ballpark value since it seems long enough to capture some initial activity for that session (so we don't send almost-empty events when opening Atom for the first time) but short enough to include quite short sessions from users (note that missing a few sessions from a user is not an issue, since now the events are persisted to disk, the issue can happen when we consistently miss all the sessions from a user).
