### PR TITLE
Fallback to not store events whenever the IndexedDB database is not available

### DIFF
--- a/src/databases/memory.ts
+++ b/src/databases/memory.ts
@@ -1,0 +1,61 @@
+import {BaseDatabase, Counters, TimingEvent, CustomEvent} from "./base";
+import {getISODate} from "../util";
+
+export default class MemoryDatabase implements BaseDatabase {
+  private counters: Counters;
+  private customEvents: CustomEvent[];
+  private timingEvents: TimingEvent[];
+
+  public constructor() {
+    this.counters = Object.create(null);
+    this.customEvents = [];
+    this.timingEvents = [];
+  }
+
+  public async addCustomEvent(eventType: string, customEvent: object) {
+    const eventToInsert = {
+      ...customEvent,
+      date: getISODate(),
+      eventType,
+    };
+
+    this.customEvents.push(eventToInsert);
+  }
+
+  public async incrementCounter(counterName: string) {
+    this.counters[counterName] = (this.counters[counterName] || 0) + 1;
+  }
+
+  public async addTiming(eventType: string, durationInMilliseconds: number, metadata: object = {}) {
+    const timingData = {
+      eventType,
+      durationInMilliseconds,
+      metadata,
+      date: getISODate(),
+    };
+
+    this.timingEvents.push(timingData);
+  }
+
+  public async clearData() {
+    this.counters = Object.create(null);
+    this.customEvents = [];
+    this.timingEvents = [];
+  }
+
+  public async getTimings(): Promise<TimingEvent[]> {
+    return this.timingEvents;
+  }
+
+  public async getCustomEvents(): Promise<CustomEvent[]> {
+    return this.customEvents;
+  }
+
+  /**
+   * Get all counters.
+   * Returns something like { commits: 7, coAuthoredCommits: 8 }.
+   */
+  public async getCounters(): Promise<Counters> {
+    return this.counters;
+  }
+}

--- a/test/databases/database.spec.ts
+++ b/test/databases/database.spec.ts
@@ -2,6 +2,7 @@ import { assert } from "chai";
 import {BaseDatabase} from "../../src/databases/base";
 import LokiDatabase from "../../src/databases/loki";
 import IndexedDBDatabase from "../../src/databases/indexeddb";
+import MemoryDatabase from "../../src/databases/memory";
 
 const grammar = "javascript";
 const openEventType = "open";
@@ -11,7 +12,7 @@ const deprecateEventType = "deprecate";
 const message = "oh noes";
 const deprecateEvent = { message, eventType: deprecateEventType };
 
-for (const DatabaseImpl of [LokiDatabase, IndexedDBDatabase]) {
+for (const DatabaseImpl of [LokiDatabase, IndexedDBDatabase, MemoryDatabase]) {
 describe(`database - ${DatabaseImpl.name}`, async function() {
   const counterName = "commits";
   let database: BaseDatabase;


### PR DESCRIPTION
## Context

We've just realized that Electron locks the `IndexedDB` database when it's opened, so multiple processes cannot access it concurrently (which makes a lot of sense 😅). This causes issues when using multiple versions of Atom at the same time, since the Electron folder (which is where the `IndexedDB` files are stored) is common between versions.

When this happens, `IndexedDB.open()` throws an error, which we're currently not handling so it appears on the development console (the exception actually appears each time an event is logged, since we're awaiting the resulting promise from `IndexedDB.open()` for each event).

## Solution

This PR consists of two commits:

1. The first one takes care of handling the `IndexedDB` exceptions and converting all the methods to store/retrieve metrics into noops, so no more exceptions are shown in `console`.
2. The second commit goes a step further, and takes advantage of the new generic way of creating stores for `telemetry` to create an in-memory storage class that is used as a fallback whenever the `IndexedDB` database is not available.

Thanks to this, if for some reason we can't operate with the `IndexedDb`, metrics will still get generated and reported (but not persisted between sessions).